### PR TITLE
fix: Ensure application exits properly on macOS cmd+q

### DIFF
--- a/src/main/java/be/nabu/eai/developer/Main.java
+++ b/src/main/java/be/nabu/eai/developer/Main.java
@@ -168,8 +168,7 @@ public class Main extends Application {
 	
 	@Override
 	public void stop() throws Exception {
-		controller.close();
-		super.stop();
+		System.exit(0);
 	}
 
 	// keep a query sheet


### PR DESCRIPTION
Use System.exit(0) to ensure the JVM terminates completely when the application is closed via cmd+q or window close on macOS.